### PR TITLE
Sigma-9 Blockquote Div CSS

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -850,6 +850,27 @@ box-shadow: -1px -1px 2px #333;
     text-decoration: none;
 }
 
+/* Blockquote Mimic Dic */
+div.blockquote {
+    border: 1px dashed #999;
+    background-color: #f4f4f4;
+    padding: 0 1em;
+    margin: 1em 3em;
+}
+ 
+@media (max-width: 479px) { 
+    div.blockquote {
+        margin: 1em 0;
+    }
+}
+ 
+@media (min-width: 480px) and (max-width: 580px) { 
+    div.blockquote {
+        margin: 0.5em;
+    }
+}
+
+
 /*
     2011-11-13 Minobe Hiroyuki @ Marguerite Site
     www.marguerite.jp/Nihongo/WWW/CSSTips/EmphasizeDots-CSS3.html


### PR DESCRIPTION
There is a proliferation of CSS on the mainsite that attempts to mimic the native quoteblocks created with >. However, many of these divs are not compatible with mobile. Itis possible to add a div class to Sigma-9 that would mimic the native quoteblocks perfectly, and therefore work on mobile and be easy for users to use.

```css
div.blockquote {
    border: 1px dashed #999;
    background-color: #f4f4f4;
    padding: 0 1em;
    margin: 1em 3em;
}
 
@media (max-width: 479px) { 
    div.blockquote {
        margin: 1em 0;
    }
}
 
@media (min-width: 480px) and (max-width: 580px) { 
    div.blockquote {
        margin: 0.5em;
    }
}
```

Credit to aismallard (@ammongit) for making the code.