### PR TITLE
Add @media query for topbar fix.

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -1109,6 +1109,32 @@ word-break: keep-all;
 
 }
 
+/* Small Mobile Media Query */
+@media (max-width: 385px) {
+#header {
+	background-position: 5% 5.5em;
+}
+
+#header h1, #header h2 {
+	margin-left: -webkit-calc(66px + 5%);
+	margin-left: -moz-calc(66px + 5%);
+	margin-left: calc(66px + 5%);
+}
+
+#header, #top-bar {
+	width: 100%;
+	max-width: 100%;
+}
+
+.mobile-top-bar {
+	width: 100%;
+}
+
+#top-bar li a {
+	padding: 10px 0.5em;
+}
+}
+
 /* Note Media Query */
 @media (min-width: 480px) and (max-width: 580px) {
 #search-top-box-input {

--- a/sigma9.css
+++ b/sigma9.css
@@ -4,7 +4,7 @@
 	Created for the SCP Foundation by Aelanna
 	Edited for SCP Foundation by Dr Devan
 */
- 
+
 /* COMMON */
 #content-wrap {
 	position: relative;
@@ -41,7 +41,7 @@ ul {
 #top-bar ul {
 	/* list-style-image: none; /* IE ONLY! IF list-style-image IS SET */
 }
- 
+
 li, p {
 	line-height: 141%;
 }
@@ -64,7 +64,7 @@ a:hover {
 	text-decoration: underline;
 	background-color: transparent;
 }
- 
+
 .form-control {
 width: 95%;
 }
@@ -75,7 +75,7 @@ width: 95%;
 	max-width: 980px;
 	margin: 0 auto;
 }
- 
+
 #top-bar {
 	width: 100%;
 	margin: 0 auto;
@@ -88,7 +88,7 @@ width: 95%;
 	bottom: 0px;
 	z-index: 0;
 }
- 
+
 body {
 	background-color: #fff;
 	font-size: 0.80em;
@@ -98,10 +98,10 @@ div#container-wrap {
 	background: url(http://www.scp-wiki.net/local--files/component:theme/body_bg.png) top left repeat-x;
 }
 
-.footnoteref, #page-content > sup {  
- vertical-align: top; position: relative; top: -0.5em; 
+.footnoteref, #page-content > sup {
+ vertical-align: top; position: relative; top: -0.5em;
 }
- 
+
 /* HEADER */
 #header {
 	height: 140px;
@@ -152,7 +152,7 @@ div#container-wrap {
 	background: linear-gradient(to bottom, #c99,#966,#633);
 	box-shadow: 0 1px 3px rgba(0,0,0,.8);
 }
- 
+
 #login-status {
 	color: #aaa;
 	font-size: 90%;
@@ -166,16 +166,16 @@ div#container-wrap {
 	color: #700;
 	background: transparent;
 }
- 
+
 #account-topbutton {
 	background: #ccc;
 	color: #700;
 }
- 
+
 .printuser img.small {
 	margin-right: 1px;
 }
- 
+
 #header h1 {
 	margin-left: 120px;
 	padding: 0;
@@ -190,7 +190,7 @@ div#container-wrap {
 	font-size: 105%;
 	max-height: 38px;
 }
- 
+
 #header h1 a {
 	display: block;
 	margin: 0;
@@ -205,7 +205,7 @@ div#container-wrap {
 	text-shadow: 3px 3px 5px #000;
 	letter-spacing: 0.9px;
 }
- 
+
 #header h2 span {
 	display: block;
 	margin: 0;
@@ -217,7 +217,7 @@ div#container-wrap {
 	text-shadow: 1px 1px 1px #000;
 	text-shadow: 1px 1px 1px rgba(0,0,0,.8);
 }
- 
+
 /* TOP MENU */
 #top-bar {
 	position: absolute;
@@ -264,7 +264,7 @@ div#container-wrap {
 	max-height: 1px;
 	overflow: hidden;
 }
- 
+
 #top-bar ul li.sfhover a,
 #top-bar ul li:hover a {
 	background: #eee;
@@ -272,7 +272,7 @@ div#container-wrap {
 	border-left: solid 1px rgba(64,64,64,1);
 	border-right: solid 1px rgba(64,64,64,1);
 }
- 
+
 #top-bar ul li.sfhover ul li a,
 #top-bar ul li:hover ul li a {
 	border-width: 0;
@@ -308,12 +308,12 @@ div#container-wrap {
 .top-bar ul li:last-of-type ul {
 	right: 0;
 }
- 
+
 /* IE7 HACK */
-#top-bar ul > li > ul {	
+#top-bar ul > li > ul {
 	*margin-top: -4px;
 }
- 
+
 /* SIDE MENU */
 #side-bar {
 	clear: none;
@@ -375,7 +375,7 @@ div#container-wrap {
 }
 #side-bar div.menu-item.sub-item {
 }
- 
+
 #side-bar .collapsible-block-folded {
 	background: url(http://www.scp-wiki.net/local--files/nav:side/expand.png) 0 2px no-repeat;
 }
@@ -418,7 +418,7 @@ div#container-wrap {
 	margin: -1em 0 1em;
 	font-weight: 85%;
 }
- 
+
 /* YUI-TABS */
 .yui-navset .yui-content{
 	background-color: #f5f5f5;
@@ -450,7 +450,7 @@ div#container-wrap {
 .yui-navset li {
 	line-height: normal;
 }
- 
+
 /* FOOTER */
 #footer {
 	clear: both;
@@ -472,7 +472,7 @@ div#container-wrap {
 	color: #fff;
 	background: transparent;
 }
- 
+
 /* SOME NICE BOXES */
 div.sexy-box {
 	background: #eee;
@@ -486,12 +486,12 @@ div.sexy-box div.image-container img {
 	padding: 2px;
 	border: 1px solid #999;
 }
- 
+
 /* Custom page content classes */
 #page-content {
 	min-height: 720px;
 }
- 
+
 .unmargined > p {
 	margin: 0;
 	line-height: 100%;
@@ -522,7 +522,7 @@ div.sexy-box div.image-container img {
 	float: right;
 	width: 48%;
 }
- 
+
 .content-panel .panel-heading {
 	padding: 2px 10px;
 	color: #ffffff;
@@ -564,7 +564,7 @@ div.sexy-box div.image-container img {
 .alternate:nth-child(even) {
 	background-color: rgba(255,255,255,.9);
 }
- 
+
 /* Page Rating Module Customizations */
 .page-rate-widget-box {
 	display: inline-block;
@@ -616,7 +616,7 @@ div.sexy-box div.image-container img {
 	color: #fffff0;
 	text-decoration: none;
 }
- 
+
 /* Heritage Collection Rating Module */
 .heritage-rating-module {
 	display: inline-block;
@@ -648,9 +648,9 @@ div.sexy-box div.image-container img {
 	height: 20px;
 	border: 0;
 }
- 
+
 /* Fixes for multi-line page tags */
- 
+
 #main-content .page-tags {
 	margin: 1em 0 0;
 	padding: 0;
@@ -664,7 +664,7 @@ div.sexy-box div.image-container img {
 	display: inline-block;
 	white-space: nowrap;
 }
- 
+
 /* Standard Image Block */
 .scp-image-block {
 	border: solid 1px #666;
@@ -714,7 +714,7 @@ div.sexy-box div.image-container img {
 	font-weight: bold;
 	font-size: 75%;
 }
- 
+
 /* Forum Customizations */
 .forum-thread-box .description-block {
 	padding: .5em 1em;
@@ -732,14 +732,14 @@ div.sexy-box div.image-container img {
 	box-shadow: inset 2px 3px 6px rgba(0,0,0,.15);
 	border-radius: 5px 5px 0 0;
 }
- 
+
 /* Hide Forum Signatures */
 .signature {
 	display:none !important;
 }
 
 /* Ruby by Nanimono Demonai */
- 
+
 .ruby, ruby {
 	display:inline-table;
 	text-align:center;
@@ -748,7 +748,7 @@ div.sexy-box div.image-container img {
 	height:1em;
 	vertical-align:text-bottom;
 }
- 
+
 .rt, rt {
 	display:table-header-group;
 	font-size:0.6em;
@@ -756,9 +756,9 @@ div.sexy-box div.image-container img {
 	text-align:center;
 	white-space:nowrap;
 }
- 
+
 /* Keycap */
- 
+
 .keycap {
 	border: 1px solid;
 	border-color: #ddd #bbb #bbb #ddd;
@@ -772,7 +772,7 @@ div.sexy-box div.image-container img {
 	font-size: 0.85em;
 	white-space: nowrap;
 }
- 
+
 /* tag style */
 
 .tags {
@@ -857,14 +857,14 @@ div.blockquote {
     padding: 0 1em;
     margin: 1em 3em;
 }
- 
-@media (max-width: 479px) { 
+
+@media (max-width: 479px) {
     div.blockquote {
         margin: 1em 0;
     }
 }
- 
-@media (min-width: 480px) and (max-width: 580px) { 
+
+@media (min-width: 480px) and (max-width: 580px) {
     div.blockquote {
         margin: 0.5em;
     }
@@ -913,38 +913,38 @@ div.blockquote {
     background-size: 1em 1.3em, auto;
 }
 }
- 
+
 /* viewport */
- 
+
 @viewport {
 	width: device-width;
 	zoom: 1.0;
 }
- 
+
 /* IE viewport */
 @-ms-viewport {
 	width: device-width;
 	zoom: 1.0;
 }
- 
+
 /* opera viewport */
 @-o-viewport {
 	width: device-width;
 	zoom: 1.0;
 }
- 
+
 /* chrome viewport - maybe it isn't work... */
 @-webkit-viewport {
 	width: device-width;
 	zoom: 1.0;
 }
- 
+
 /* firefox viewport - maybe it isn't work too... */
 @-moz-viewport {
 	width: device-width;
 	zoom: 1.0;
 }
- 
+
 /* webkit scrollbar */
 ::-webkit-scrollbar
 {
@@ -953,12 +953,12 @@ div.blockquote {
 	border: solid 1px rgba(0, 0, 0, 0.1);
 	border-round: 0.5px;
 }
- 
+
 ::-webkit-scrollbar-track
 {
 	background: rgba(0, 0, 0, 0.1);
 }
- 
+
 ::-webkit-scrollbar-thumb
 {
 	background: rgba(50, 50, 50, 0.3);
@@ -972,7 +972,7 @@ word-break: break-all;
 img, embed, video, object, iframe, table {
 	max-width: 100%;
 }
- 
+
 #page-content div, #page-content div table {
 	max-width: 100%;
 }
@@ -1010,68 +1010,68 @@ span, a {
 word-break: break-all;
 }
 }
- 
+
 /* Mobile Media Query */
-@media (max-width: 479px) { 
+@media (max-width: 479px) {
 #search-top-box-input {
 	display: none;
 }
- 
+
 #page-content {
 	font-size: 0.9em;
 }
- 
+
 #main-content {
 	margin: 0;
 }
- 
+
 #recent-posts-category {
 width: 100%;
 }
- 
+
 #header, .mobile-top-bar {
 	max-width: 90%;
 }
- 
+
 #side-bar {
 	width: 80%;
 	position: relative;
 }
- 
+
 .top-bar {
 	display:none;
 }
- 
+
 .mobile-top-bar {
 	display: block;
 	padding: 0;
 }
- 
+
 .page-options-bottom a {
 	padding: 0 4px;
 }
- 
+
 #header h1 a {
 	font-size: 100%;
 }
- 
+
 blockquote {
 	margin: 1em 0;
 }
- 
+
 .license-area {
 	font-size: 0.8em;
 }
- 
+
 #header {
 	background-position: 0 5.5em;
 	background-size: 55px 55px;
 }
- 
+
 #header h1, #header h2 {
 	margin-left: 66px;
 }
- 
+
 table.form td, table.form th {
 	float: left;
 }
@@ -1108,55 +1108,55 @@ word-break: keep-all;
 }
 
 }
- 
+
 /* Note Media Query */
-@media (min-width: 480px) and (max-width: 580px) { 
+@media (min-width: 480px) and (max-width: 580px) {
 #search-top-box-input {
 	width: 7em;
 }
- 
+
 #main-content {
 	margin: 0 2em 0 2em;
 }
- 
+
 #header, .mobile-top-bar {
 	max-width: 90%;
 }
- 
+
 #side-bar {
 	width: 80%;
 	position: relative;
 }
- 
+
 .top-bar {
 	display:none;
 }
- 
+
 .mobile-top-bar {
 	display: block;
 }
- 
+
 .page-options-bottom a {
 	padding: 0 5px;
 }
- 
+
 #header h1 a {
 	font-size: 120%;
 }
- 
+
 blockquote {
 	margin: 0.5em;
 }
- 
+
 .license-area {
 	font-size: 0.85em;
 }
- 
+
 #header {
 	background-position: 0.5em 4.5em;
 	background-size: 66px 66px;
 }
- 
+
 #header h1, #header h2 {
 	margin-left: 80px;
 }
@@ -1184,26 +1184,26 @@ float: left;
 clear: both;
 }
 }
- 
+
 /* Mini Tablet Media Query */
-@media (min-width: 581px) and (max-width: 767px) { 
+@media (min-width: 581px) and (max-width: 767px) {
 #search-top-box-input {
 	width: 8em;
 }
- 
+
 #side-bar {
 	width: 80%;
 	position: relative;
 }
- 
+
 #main-content {
 	margin: 0 3em 0 2em;
 }
- 
+
 #header, .mobile-top-bar {
 	max-width: 90%;
 }
- 
+
 .top-bar {
 	display: none;
 }
@@ -1211,39 +1211,39 @@ clear: both;
 .mobile-top-bar {
 	display: block;
 }
- 
+
 .page-options-bottom a {
 	padding: 0 6px;
 }
- 
+
 #header h1 a {
 	font-size: 140%;
 }
- 
+
 .license-area {
 	font-size: 0.9em;
 }
- 
+
 #header {
 	background-position: 1em 4em;
 	background-size: 77px 77px;
 }
- 
+
 #header h1, #header h2 {
 	margin-left: 93px;
 }
 }
- 
+
 /* Tablet Media Query */
 @media (min-width: 768px) and (max-width: 979px) {
 #main-content {
 	margin: 0 4em 0 20em;
 }
- 
+
 #header, #top-bar #side-bar {
 	max-width: 100%;
 }
- 
+
 .top-bar li {
 	margin: 0;
 }
@@ -1251,24 +1251,24 @@ clear: both;
 #top-bar ul li.sfhover ul li a, #top-bar ul li:hover ul li a {
 	width: 110px;
 }
- 
+
 .page-options-bottom a {
 	padding: 0 7px;
 }
- 
+
 #header h1 a {
 	font-size: 160%;
 }
- 
+
 .license-area {
 	font-size: 0.95em;
 }
- 
+
 #header {
 	background-position: 1em 4em;
 	background-size: 88px 88px;
 }
- 
+
 #header h1, #header h2 {
 	margin-left: 106px;
 }
@@ -1282,7 +1282,7 @@ float: left;
 clear: both;
 }
 }
- 
+
 /* Desktop Media Query -----------
 @media (min-width: 980px) and (max-width: 1399px) {
 
@@ -1294,13 +1294,13 @@ clear: both;
 
 }
 ------------------------------------------ */
- 
+
 /* off-canvas */
- 
+
 .close-menu {
 	display: none;
 }
- 
+
 @media (max-width: 767px) {
 
 .page-history tbody tr td:last-child {
@@ -1354,7 +1354,7 @@ z-index: 1;
 	border-radius: 3em;
 	color: #888 !important;
 }
- 
+
 .open-menu a:hover {
 	text-decoration: none !important;
 	-webkit-box-shadow: 0px 0px 20px 3px rgba(153,153,153,1);
@@ -1363,7 +1363,7 @@ z-index: 1;
 	-o-box-shadow: 0px 0px 20px 3px rgba(153,153,153,1);
 	box-shadow: 0px 0px 20px 3px rgba(153,153,153,1);
 }
- 
+
 #main-content {
 	max-width: 90%;
 	margin: 0 5%;
@@ -1374,7 +1374,7 @@ z-index: 1;
 	-o-transition: 0.5s ease-in-out 0.1s;
 	transition: 0.5s ease-in-out 0.1s;
 }
- 
+
 #side-bar {
 	display: block;
 	position: fixed;
@@ -1392,7 +1392,7 @@ z-index: 1;
 	-o-transition: left 0.5s ease-in-out 0.1s;
 	transition: left 0.5s ease-in-out 0.1s;
 }
- 
+
 #side-bar:after {
 	content: "";
 	position: absolute;
@@ -1400,9 +1400,9 @@ z-index: 1;
 	width: 0;
 	height: 100%;
 	background-color: rgba(0, 0, 0, 0.2);
- 
+
 }
- 
+
 #side-bar:target {
 	display: block;
 	left: 0;
@@ -1411,11 +1411,11 @@ z-index: 1;
 	border: 1px solid #dedede;
 	z-index: 10;
 }
- 
+
 #side-bar:target + #main-content {
 	left: 0;
 }
- 
+
 #side-bar:target .close-menu {
 	display: block;
 	position: fixed;
@@ -1426,7 +1426,7 @@ z-index: 1;
 	background: rgba(0,0,0,0.3) 1px 1px repeat;
 	z-index: -1;
 }
-	
+
 div.scpnet-interwiki-wrapper {
     width: 17em;
     margin-left: -5px;


### PR DESCRIPTION
As tested in http://scptestwiki.wikidot.com/sigma:topbar

Thanks to @woedenaz 

This PR also strips trailing whitespace. To ignore that and only see the relevant diff, check the following in the cog on the files tab:

![image](https://user-images.githubusercontent.com/8848022/73709989-a692c580-46d0-11ea-9069-6a55ab0a0602.png)
