### PR TITLE
Footnote Fix

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -98,8 +98,10 @@ div#container-wrap {
 	background: url(http://www.scp-wiki.net/local--files/component:theme/body_bg.png) top left repeat-x;
 }
 
-.footnoteref, #page-content > sup {
- vertical-align: top; position: relative; top: -0.5em;
+sup {
+    vertical-align: top; 
+    position: relative; 
+    top: -0.5em;
 }
 
 /* HEADER */


### PR DESCRIPTION
The current CSS leads to footnotes floating too high and into the next line. This is a change back to the original CSS before this bug appeared.