### PR TITLE
Fix sidebar scrolling on Firefox

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -351,6 +351,7 @@ sup {
 	padding: 0;
 	border: none;
 	display: block;
+	overscroll-behavior: none;
 }
 
 #side-bar .side-block {


### PR DESCRIPTION
Recieved a report that sidebar scroll was not working on mobile Firefox. Was able to reproduce on mobile Firefox 68.5.0 and desktop Firefox Developer 73.0b12. Works fine in Chromium.

![image](https://user-images.githubusercontent.com/29130152/75472870-1b81b400-598c-11ea-931d-04765c36d6c6.png)

Adding `overscroll-behavior: none` to `#side-bar` appears to fix this.