### PR TITLE
Update to Side-Bar Colors

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -363,6 +363,14 @@ sup {
 	margin-bottom: 15px;
 }
 
+#side-bar .side-block.media {
+        background: #e5e5ff;
+}
+
+#side-bar .side-block.resources {
+        background: #fff0f0;
+}
+
 #side-bar .side-area {
 	padding: 10px;
 }


### PR DESCRIPTION
This is a technical change which alters how the different colors on the side-bar are achieved, allowing for easier/targeted alteration of those divs on individual themes without having to rely on !important tags. This both makes it easier for users to alter the elements themselves, and removes style elements from the site function. Nothing will change on the user end.

If implemented, the following changes would be made to nav:side (http://www.scp-wiki.net/nav:side):

From:
```
[[div class="side-block" style="background-color: #e5e5ff;"]]
```
To:
```
[[div class="side-block media"]]
```

From:
```
[[div class="side-block" style="background-color: #fff0f0;"]]
```
To:
```
[[div class="side-block resources"]]
```