### PR TITLE
Make .side-block style accessible from outside #side-bar

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -354,7 +354,7 @@ sup {
 	overscroll-behavior: none;
 }
 
-#side-bar .side-block {
+.side-block {
 	padding: 10px;
 	border: 1px solid #660000;
 	border-radius: 10px;


### PR DESCRIPTION
The sidebar side block styling is pretty synonymous with the vibe of the site - at least, for those that use sigma9. Pages that reproduce the sigma9 style have an official air to them, implying endorsement by the site - for example the rounded boxes on the front page. It makes sense to me to make the side block style accessible by elements outside of the sidebar to reduce code duplication.