### PR TITLE
Do not modify word break on mobile

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -1095,10 +1095,6 @@ img, embed, video, object, iframe, table {
 .mobile-top-bar ul li:last-of-type ul {
 	right: 0;
 }
-
-span, a {
-	word-break: break-all;
-}
 }
 
 /* Mobile Media Query */


### PR DESCRIPTION
Sigma-9 changes the word break setting on `span` and `a`, arbitrarily breaking those elements in the middle of words, which is both arbitrary and stupid.

Do not merge yet - we need to investigate what effects this will have, and why it was considered necessary in the first place.