### PR TITLE
Remove nonexistant dot.png

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -6,7 +6,7 @@
 */
 
 @charset "utf-8";
- 
+
 @import url('https://scp-wiki.wdfiles.com/local--files/component%3Atheme/font-bauhaus.css');
 @import url('https://fonts.googleapis.com/earlyaccess/nanumgothic.css');
 @import url('https://fonts.googleapis.com/earlyaccess/nanumgothiccoding.css');
@@ -964,7 +964,6 @@ div.curved {
 	font-family: monospace;
 	font-style: normal;
 	font-weight: normal;
-	background-image: url(https://scp-wiki.wdfiles.com/local--files/component%3Atheme/dot.png), none;
 	background-repeat: repeat-x;
 	padding: 0.5em 0 0;
 	background-color:transparent;
@@ -980,7 +979,6 @@ div.curved {
 	font-family: monospace;
 	font-style: normal;
 	font-weight: normal;
-	background-image: url(https://scp-wiki.wdfiles.com/local--files/component%3Atheme/dot.png), none;
 	background-repeat: repeat-x;
 	padding: 0.5em 0 0;
 	background-color:transparent;


### PR DESCRIPTION
Going back as far as https://web.archive.org/web/20150606072324/http://scp-wiki.wdfiles.com/local--files/component%3Atheme/dot.png there is no record of dot.png

Given we've gone this far without needing it, we should just remove it
from the CSS.