### PR TITLE
Remove !important tags from Sigma-9

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -1406,7 +1406,7 @@ td.name {
 	display: none;
 }
 
-#top-menu .open-menu a {
+#top-bar .open-menu a {
 	position: fixed;
 	top: 0.5em;
 	left: 0.5em;
@@ -1424,7 +1424,7 @@ td.name {
 	color: #888;
 }
 
-#top-menu .open-menu a:hover {
+#top-bar .open-menu a:hover {
 	text-decoration: none;
 	-webkit-box-shadow: 0px 0px 20px 3px rgba(153,153,153,1);
 	-moz-box-shadow: 0px 0px 20px 3px rgba(153,153,153,1);

--- a/sigma9.css
+++ b/sigma9.css
@@ -1406,7 +1406,7 @@ td.name {
 	display: none;
 }
 
-.open-menu a {
+#top-menu .open-menu a {
 	position: fixed;
 	top: 0.5em;
 	left: 0.5em;
@@ -1418,14 +1418,14 @@ td.name {
 	height: 30px;
 	line-height: 0.9em;
 	text-align: center;
-	border: 0.2em solid #888 !important;
-	background-color: #fff !important;
+	border: 0.2em solid #888;
+	background-color: #fff;
 	border-radius: 3em;
-	color: #888 !important;
+	color: #888;
 }
 
-.open-menu a:hover {
-	text-decoration: none !important;
+#top-menu .open-menu a:hover {
+	text-decoration: none;
 	-webkit-box-shadow: 0px 0px 20px 3px rgba(153,153,153,1);
 	-moz-box-shadow: 0px 0px 20px 3px rgba(153,153,153,1);
 	-ms-box-shadow: 0px 0px 20px 3px rgba(153,153,153,1);


### PR DESCRIPTION
Currently, the burger stack button that opens the side-bar is coded with the following (some lines trimmed for conciseness).

```css
.open-menu a {
    border: 0.2em solid #888 !important;
    background-color: #fff !important;
    color: #888 !important;
}
 
.open-menu a:hover {
    text-decoration: none !important;
}
```

This uses four !important tags. These tags are necessary because the CSS used to style the top-bar links in general is more specific (using `#top-bar a`) than the code used to code the burger stack. By changing the selector and putting a `#top-bar` before `.open-menu a`, the correct order will be established, and the !important tags can be removed.