### PR TITLE
Update SCP Wiki URL in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Sigma-9
 
-This is the repository for the Sigma-9 theme, the default CSS used to style the [SCP Wiki](http://www.scp-wiki.net). It was originally created by [Aelanna](http://www.wikidot.com/user:info/aelanna) and is presently maintained by the SCP Wiki Technical Team.
+This is the repository for the Sigma-9 theme, the default CSS used to style the [SCP Wiki](http://www.scpwiki.com). It was originally created by [Aelanna](http://www.wikidot.com/user:info/aelanna) and is presently maintained by the SCP Wiki Technical Team.
 
 This theme is available under the wiki's [Creative Commons Attribution-ShareAlike 3.0 license (CC-BY-SA)](https://creativecommons.org/licenses/by-sa/3.0/).
 


### PR DESCRIPTION
I was also considering whether to use the HTTPS `scp-wiki.wikidot.com` URL.