### PR TITLE
Psuedocrumbs

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -461,6 +461,10 @@ sup {
 	margin: -1em 0 1em;
 }
 
+.pseudocrumbs {
+    margin: -1em 0 1em;
+}
+
 /* YUI-TABS */
 .yui-navset .yui-content {
 	background-color: #f5f5f5;

--- a/sigma9.css
+++ b/sigma9.css
@@ -462,7 +462,7 @@ sup {
 }
 
 .pseudocrumbs {
-    margin: -1em 0 1em;
+	margin: -1em 0 1em;
 }
 
 /* YUI-TABS */


### PR DESCRIPTION
Add a class to Sigma-9 that allows users to create a div that mimics the appearance of the standard page parenting links at the top of the page, so they can create the appearance of making their page look like it has been parented to multiple pages. Used as follows:

```css
[[div class="pseudocrumbs"]]
[[[Groups Of Interest]]] » [[[marshall-carter-and-dark-hub|Marshall, Carter and Dark Hub]]] » 'Night's Collection' (Lot C3S81)
[[[Groups Of Interest]]] » [[[chicago-spirit|GOI-001: Chicago Spirit]]] » [[[black-as-night|Black As Night Hub ]]] » 'Night's Collection' (Lot C3S81)
[[/div]]
```