### PR TITLE
Add a CSS Class for Fake Titles

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -46,11 +46,11 @@ h2, h3, h4, h5, h6 {
 }
 
 .meta-title {
-	border-bottom: solid 1px #bbbbbb;
-	color: #990011;
+	border-bottom: solid 1px #bbb;
+	color: #901;
 	font-weight: normal;
-	margin: 0 0 0.6em;
-	padding: 0 0 0.25em;
+	margin: 0 0 .6em;
+	padding: 0 0 .25em;
 	font-size: 200%;
 }
 

--- a/sigma9.css
+++ b/sigma9.css
@@ -46,16 +46,16 @@ h2, h3, h4, h5, h6 {
 }
 
 .meta-title {
-  border-bottom: solid 1px #bbbbbb;
-  color: #990011;
-  font-weight: normal;
-  margin: 0 0 0.6em;
-  padding: 0 0 0.25em;
-  font-size: 200%;
+	border-bottom: solid 1px #bbbbbb;
+	color: #990011;
+	font-weight: normal;
+	margin: 0 0 0.6em;
+	padding: 0 0 0.25em;
+	font-size: 200%;
 }
 
 .meta-title p {
-  margin: 0;
+	margin: 0;
 }
 
 ul {

--- a/sigma9.css
+++ b/sigma9.css
@@ -45,6 +45,19 @@ h2, h3, h4, h5, h6 {
 	border-color: #bbb;
 }
 
+.meta-title {
+  border-bottom: solid 1px #bbbbbb;
+  color: #990011;
+  font-weight: normal;
+  margin: 0 0 0.6em;
+  padding: 0 0 0.25em;
+  font-size: 200%;
+}
+
+.meta-title p {
+  margin: 0;
+}
+
 ul {
 	list-style: square;
 }


### PR DESCRIPTION
Many users like to change the title that appears on their pages, so that they are not a 1:1 match to the url or Wikidot page name. This has been used on a number of articles with consistent CSS, and adding it to Sigma-9 would allow it to be more uniformly used.