### PR TITLE
Add CSS Class for Licensebox to Sigma-9

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -762,14 +762,14 @@ div.sexy-box div.image-container img {
 
 /* Licensebox */
 .licensebox .collapsible-block-link {
-	margin-left:.25em;
+	margin-left: .25em;
 	padding: .25em;
 	font-weight: bold;
 	opacity: .5;
 	color: inherit;
-	-webkit-transition: opacity 0.5s ease-in-out;
-	-moz-transition: opacity 0.5s ease-in-out;
-	transition: opacity 0.5s ease-in-out;
+	-webkit-transition: opacity .5s ease-in-out;
+	-moz-transition: opacity .5s ease-in-out;
+	transition: opacity .5s ease-in-out;
 }
 
 .licensebox .collapsible-block-link:hover {

--- a/sigma9.css
+++ b/sigma9.css
@@ -760,6 +760,27 @@ div.sexy-box div.image-container img {
 	font-size: 75%;
 }
 
+/* Licensebox */
+.licensebox .collapsible-block-link {
+	margin-left:.25em;
+	padding: .25em;
+	font-weight: bold;
+	opacity: .5;
+	color: inherit;
+	-webkit-transition: opacity 0.5s ease-in-out;
+	-moz-transition: opacity 0.5s ease-in-out;
+	transition: opacity 0.5s ease-in-out;
+}
+
+.licensebox .collapsible-block-link:hover {
+	opacity: 1;
+}
+
+.licensebox .collapsible-block-link:active {
+	opacity: 1;
+}
+
+
 /* Forum Customizations */
 .forum-thread-box .description-block {
 	padding: .5em 1em;

--- a/sigma9.css
+++ b/sigma9.css
@@ -772,14 +772,10 @@ div.sexy-box div.image-container img {
 	transition: opacity .5s ease-in-out;
 }
 
-.licensebox .collapsible-block-link:hover {
-	opacity: 1;
-}
-
+.licensebox .collapsible-block-link:hover,
 .licensebox .collapsible-block-link:active {
 	opacity: 1;
 }
-
 
 /* Forum Customizations */
 .forum-thread-box .description-block {


### PR DESCRIPTION
Given that the Licensebox is expected to go on every Wiki page at some point, the necessary CSS to code it should be moved out of the component and into Sigma-9 as a whole.

This change also renames the class, from the previous "licensebox22" to the simpler and clearer "licensebox", removing the unnecessary number, which referred to CityToast's draft number.