### PR TITLE
Increase interwiki height to remove scrollbars

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -1527,18 +1527,13 @@ div.scpnet-interwiki-wrapper {
 }
 
 iframe.scpnet-interwiki-frame {
-	height: 300px;
+	height: 350px;
 	width: 17em;
 	border: none;
 }
 
 @media (min-width: 768px) {
-	iframe.scpnet-interwiki-frame {
-		height: 300px;
-		width: 18em;
-	}
-
-	div.scpnet-interwiki-wrapper {
+	iframe.scpnet-interwiki-frame, div.scpnet-interwiki-wrapper {
 		width: 18em;
 	}
 }


### PR DESCRIPTION
The current height of the interwiki module often leaves ugly scrollbars - a vertical scrollbar to indicate that there is not enough vertical height, and then a horizontal scrollbar to indicate that there is not enough horizontal width after the width of the vertical scrollbar has claimed what it wants.

This PR bumps the interwiki height up to 350px, which is enough to cover all the currrent translation sites.

This is not a long-term solution. As more translation sites are created, the interwiki box will need to grow ever taller and taller.