### PR TITLE
Extend sidebar styling to interwiki

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -117,6 +117,10 @@ body {
 	color: #333;
 }
 
+#interwiki body {
+	background-color: transparent;
+}
+
 div#container-wrap {
 	background: url('https://scp-wiki.wdfiles.com/local--files/component:theme/body_bg.png') top left repeat-x;
 }

--- a/sigma9.css
+++ b/sigma9.css
@@ -361,6 +361,10 @@ sup {
 	overscroll-behavior: none;
 }
 
+#interwiki .side-block {
+	margin: 5px;
+}
+
 #side-bar .side-block,
 #interwiki .side-block {
 	padding: 10px;

--- a/sigma9.css
+++ b/sigma9.css
@@ -81,7 +81,8 @@ a:hover {
 	background-color: transparent;
 }
 
-#side-bar a:visited {
+#side-bar a:visited,
+#interwiki a:visited {
 	color: #b01;
 }
 
@@ -360,7 +361,8 @@ sup {
 	overscroll-behavior: none;
 }
 
-#side-bar .side-block {
+#side-bar .side-block,
+#interwiki .side-block {
 	padding: 10px;
 	border: 1px solid #600;
 	border-radius: 10px;
@@ -381,7 +383,8 @@ sup {
 	padding: 10px;
 }
 
-#side-bar .heading {
+#side-bar .heading,
+#interwiki .heading {
 	color: #600;
 	border-bottom: solid 1px #600;
 	padding-left: 15px;
@@ -391,11 +394,13 @@ sup {
 	font-weight: bold;
 }
 
-#side-bar p {
+#side-bar p,
+#interwiki p {
 	margin: 0;
 }
 
-#side-bar .menu-item {
+#side-bar .menu-item,
+#interwiki .menu-item {
 	margin: 2px 0;
 }
 
@@ -403,7 +408,8 @@ sup {
 	font-size: 90%; /* For sidebar item with smaller text, like SCP series links */
 }
 
-#side-bar .menu-item img {
+#side-bar .menu-item img,
+#interwiki .menu-item img {
 	width: 13px;
 	height: 13px;
 	border: 0;
@@ -412,7 +418,8 @@ sup {
 	bottom: -2px;
 }
 
-#side-bar .menu-item a {
+#side-bar .menu-item a,
+#interwiki .menu-item a {
 	font-weight: bold;
 }
 

--- a/sigma9.css
+++ b/sigma9.css
@@ -1481,7 +1481,7 @@ div.scpnet-interwiki-wrapper {
 }
 
 iframe.scpnet-interwiki-frame {
-	height: 400px;
+	height: 0;
 	width: 17em;
 	border: none;
 }


### PR DESCRIPTION
This should theoretically allow Sigma-9 to be imported to the new Interwiki (https://github.com/scpwiki/interwiki) without needing any sort of custom extra theme. This is the method of styling the new Interwiki that involves the least amount of effort.

Will mark as ready once I've tested with the new interwiki (dependent on the merge of scpwiki/interwiki#3).

EDIT: It works.