### PR TITLE
Correctly align interwiki with sidebar

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -1533,14 +1533,8 @@ img, embed, video, object, iframe, table {
 	}
 }
 
-/* Interwiki is 1em wider than the sidebar to give it space for a shadow */
-iframe.scpnet-interwiki-frame, div.scpnet-interwiki-wrapper {
-	width: 18em;
-}
-
-/* Move interwiki to the left by half of 1em to center-align it */
 div.scpnet-interwiki-wrapper {
-	margin-left: 0.5em;
+	margin-left: 0 -5px;
 }
 
 iframe.scpnet-interwiki-frame {

--- a/sigma9.css
+++ b/sigma9.css
@@ -1532,21 +1532,18 @@ img, embed, video, object, iframe, table {
 	}
 }
 
+/* Interwiki is 1em wider than the sidebar to give it space for a shadow */
+iframe.scpnet-interwiki-frame, div.scpnet-interwiki-wrapper {
+	width: 18em;
+}
+
 div.scpnet-interwiki-wrapper {
-	width: 17em;
 	margin-left: -5px;
 }
 
 iframe.scpnet-interwiki-frame {
 	height: 350px;
-	width: 17em;
 	border: none;
-}
-
-@media (min-width: 768px) {
-	iframe.scpnet-interwiki-frame, div.scpnet-interwiki-wrapper {
-		width: 18em;
-	}
 }
 
 /* Content Warning for adult content */

--- a/sigma9.css
+++ b/sigma9.css
@@ -364,6 +364,10 @@ sup {
 	overscroll-behavior: none;
 }
 
+#interwiki .side-block {
+	margin: 5px;
+}
+
 #side-bar .side-block,
 #interwiki .side-block {
 	padding: 10px;

--- a/sigma9.css
+++ b/sigma9.css
@@ -364,8 +364,9 @@ sup {
 	overscroll-behavior: none;
 }
 
+/* Interwiki accepts a little space to display its shadow */
 #interwiki .side-block {
-	margin: 5px;
+	margin: 0.5em;
 }
 
 #side-bar .side-block,
@@ -1537,8 +1538,9 @@ iframe.scpnet-interwiki-frame, div.scpnet-interwiki-wrapper {
 	width: 18em;
 }
 
+/* Move interwiki to the left by half of 1em to center-align it */
 div.scpnet-interwiki-wrapper {
-	margin-left: -5px;
+	margin-left: 0.5em;
 }
 
 iframe.scpnet-interwiki-frame {

--- a/sigma9.css
+++ b/sigma9.css
@@ -1534,7 +1534,7 @@ img, embed, video, object, iframe, table {
 }
 
 div.scpnet-interwiki-wrapper {
-	margin-left: 0 -5px;
+	margin: 0 -5px;
 }
 
 iframe.scpnet-interwiki-frame {

--- a/sigma9.css
+++ b/sigma9.css
@@ -81,7 +81,8 @@ a:hover {
 	background-color: transparent;
 }
 
-#side-bar a:visited {
+#side-bar a:visited,
+#interwiki a:visited {
 	color: #b01;
 }
 
@@ -363,7 +364,8 @@ sup {
 	overscroll-behavior: none;
 }
 
-#side-bar .side-block {
+#side-bar .side-block,
+#interwiki .side-block {
 	padding: 10px;
 	border: 1px solid #600;
 	border-radius: 10px;
@@ -384,7 +386,8 @@ sup {
 	padding: 10px;
 }
 
-#side-bar .heading {
+#side-bar .heading,
+#interwiki .heading {
 	color: #600;
 	border-bottom: solid 1px #600;
 	padding-left: 15px;
@@ -394,15 +397,18 @@ sup {
 	font-weight: bold;
 }
 
-#side-bar p {
+#side-bar p,
+#interwiki p {
 	margin: 0;
 }
 
-#side-bar div.menu-item {
+#side-bar div.menu-item,
+#interwiki div.menu-item {
 	margin: 2px 0;
 }
 
-#side-bar div.menu-item img {
+#side-bar div.menu-item img,
+#interwiki div.menu-item img {
 	width: 13px;
 	height: 13px;
 	border: 0;
@@ -411,7 +417,8 @@ sup {
 	bottom: -2px;
 }
 
-#side-bar div.menu-item a {
+#side-bar div.menu-item a,
+#interwiki div.menu-item a {
 	font-weight: bold;
 }
 


### PR DESCRIPTION
The interwiki was aligned to the sidebar haphazardly, with an offset value unrelated to the value that it should have been. This was presumably decided by eye.

We can see a slight imbalance in the alignment of the RU interwiki as a result of this:

![image](https://user-images.githubusercontent.com/29130152/132092865-3e3f88c0-bc93-48f1-a4e3-c8e9f254a2e9.png)

This results in an interwiki position that appears to be correct, because the RU interwiki had a fixed width. The new interwiki (https://github.com/scpwiki/interwiki), based on the CN interwiki, does not have a fixed width (unless one is set by its theme), so this correction is necessary.