### PR TITLE
Hot fix for mobile top bar space break.

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -293,8 +293,7 @@ sup {
 	border-left: solid 1px rgba(64, 64, 64, .1);
 	border-right: solid 1px rgba(64, 64, 64, .1);
 	text-decoration: none;
-	padding-top: 10px;
-	padding-bottom: 10px;
+	padding: 10px min(0.75vw, 1em);
 	line-height: 1px;
 	max-height: 1px;
 	overflow: hidden;
@@ -1217,9 +1216,6 @@ img, embed, video, object, iframe, table {
 		width: 100%;
 	}
 
-	#top-bar li a {
-		padding: 10px .5em;
-	}
 }
 
 /* Note Media Query */


### PR DESCRIPTION
Top bar a has side padding, of 1em up unti 385x, where an @ change it to 0.5em. This creates an odd gap between 385px and ~440px whre the top bar links breaks line. 

This remove the relevant at rule and compacts it with min()