### PR TITLE
remove redundant css from side-bar:target

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -529,12 +529,7 @@ sup {
 	}
 
 	#side-bar:target {
-		display: block;
 		left: 0;
-		width: 17em;
-		margin: 0;
-		border: 1px solid #dedede;
-		z-index: 10;
 	}
 
 	#side-bar:target .close-menu {


### PR DESCRIPTION
#side-bar:target contains some redundant css that can removed for simplcity. Border that only appears here are also removed. 