### PR TITLE
Correctly align interwiki with sidebar, again

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -1261,20 +1261,12 @@ img, embed, video, object, iframe, table {
 }
 
 div.scpnet-interwiki-wrapper {
-	width: 17em;
-	margin-left: -5px;
+	margin: 0 -5px;
 }
 
 iframe.scpnet-interwiki-frame {
 	height: 0;
-	width: 17em;
 	border: none;
-}
-
-@media (min-width: 768px) {
-	iframe.scpnet-interwiki-frame, div.scpnet-interwiki-wrapper {
-		width: 18em;
-	}
 }
 
 /* Content Warning for adult content */


### PR DESCRIPTION
This is a re-approach to https://github.com/scpwiki/sigma9/pull/43, by adding a 5px bump to each side using negative margin. 

Resolving this as a preliminary step for the font change.