### PR TITLE
Replace word-break with overflow-wrap

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -1134,7 +1134,7 @@ img, embed, video, object, iframe, table {
 	}
 
 	span, a {
-		word-break: break-all;
+		overflow-wrap: break-word;
 	}
 
 	.page-history tbody tr td:last-child {


### PR DESCRIPTION
As suggested in https://github.com/scpwiki/sigma9/pull/26.

Personal testing and observation saw that removing word-break: break-all has little negative effect on mobile page display.

However, it does have a niche utility in preventing links from extending beyond screen boundary, which can be more handled deftly handled with overflow-wrap instead.