### PR TITLE
Remove Search Bar Input Field

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -152,8 +152,8 @@ sup {
 /*
  * Commenting out the search box at the top while native
  * Wikidot search remains non-functional.
- */
-/*
+ *
+
 #search-top-box-input {
 	border: solid 1px #999;
 	border-radius: 5px;

--- a/sigma9.css
+++ b/sigma9.css
@@ -149,6 +149,7 @@ sup {
 	text-align: right;
 }
 
+/* Commenting out Search Top Box Input while native Wikidot Search remains non-functional.
 #search-top-box-input {
 	border: solid 1px #999;
 	border-radius: 5px;
@@ -163,6 +164,11 @@ sup {
 	color: #fff;
 	background-color: #633;
 	box-shadow: inset 1px 1px 3px rgba(0, 0, 0, .8);
+}
+*/
+
+#search-top-box-input {
+    display: none;
 }
 
 #search-top-box-form input[type='submit'] {

--- a/sigma9.css
+++ b/sigma9.css
@@ -150,8 +150,8 @@ sup {
 }
 
 /*
- * Commenting out Search Top Box Input while native
- * Wikidot Search remains non-functional.
+ * Commenting out the search box at the top while native
+ * Wikidot search remains non-functional.
  */
 #search-top-box-input {
 	border: solid 1px #999;

--- a/sigma9.css
+++ b/sigma9.css
@@ -149,7 +149,10 @@ sup {
 	text-align: right;
 }
 
-/* Commenting out Search Top Box Input while native Wikidot Search remains non-functional.
+/*
+ * Commenting out Search Top Box Input while native
+ * Wikidot Search remains non-functional.
+ */
 #search-top-box-input {
 	border: solid 1px #999;
 	border-radius: 5px;

--- a/sigma9.css
+++ b/sigma9.css
@@ -172,7 +172,7 @@ sup {
 */
 
 #search-top-box-input {
-    display: none;
+	display: none;
 }
 
 #search-top-box-form input[type='submit'] {

--- a/sigma9.css
+++ b/sigma9.css
@@ -153,6 +153,7 @@ sup {
  * Commenting out the search box at the top while native
  * Wikidot search remains non-functional.
  */
+/*
 #search-top-box-input {
 	border: solid 1px #999;
 	border-radius: 5px;


### PR DESCRIPTION
As Wikidot Search remains broken, and Crom search no longer has the redirect to retrieve the inputs of this field, the search bar input field should be hidden to prevent confusion.