### PR TITLE
redundant style on content-wrap?

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -17,8 +17,7 @@
 	margin: 2em auto 0;
 	max-width: 1040px;
 	min-height: 1300px;
-	height: auto !important;
-	height: 1500px;
+	height: auto;
 }
 
 h1, #page-title {


### PR DESCRIPTION
I have no idea why there are two height properties, with an !important on the former.

(Is there any reason why we need an !important here?)