### PR TITLE
initial

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -1116,7 +1116,7 @@ img, embed, video, object, iframe, table {
 	max-width: 100%;
 }
 
-#page-content div, #page-content div table {
+:where(#page-content) div {
 	max-width: 100%;
 }
 


### PR DESCRIPTION
Removed #page-content div table from selector due to redundancy with above.

#page-content div has high specificity (1, 0, 1); which is not necessarily trivial to override (necessitating #page-content .class-name instead of just .class-name).

:where(#page-content) div brings specificity down to (0, 0, 1).

caniuse.com pegs :where() support at 90.44% at time of writing.

https://caniuse.com/?search=where