### PR TITLE
no top margin for first child heading

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -412,6 +412,7 @@ sup {
 	font-size: 8pt;
 	font-weight: bold;
 }
+
 #side-bar .heading:where(:first-child),
 #interwiki .heading:where(:first-child) {
 	margin-top: 0;

--- a/sigma9.css
+++ b/sigma9.css
@@ -412,6 +412,10 @@ sup {
 	font-size: 8pt;
 	font-weight: bold;
 }
+#side-bar .heading:where(:first-child),
+#interwiki .heading:where(:first-child) {
+	margin-top: 0;
+}
 
 #side-bar p,
 #interwiki p {


### PR DESCRIPTION
.heading has a default top margin of 10px, which creates unnecessary gap if it's the first item in the block.