### PR TITLE
remove unneeded default width on imageblock childs

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -842,7 +842,6 @@ div.page-rate-widget-box .rate-points {
 
 .scp-image-block img {
 	border: 0;
-	width: 300px;
 }
 
 .scp-image-block .scp-image-caption {
@@ -852,7 +851,6 @@ div.page-rate-widget-box .rate-points {
 	font-size: 80%;
 	font-weight: bold;
 	text-align: center;
-	width: 300px;
 }
 
 .scp-image-block > p {


### PR DESCRIPTION
.scp-image-block img and .scp-image-caption has width set on it, which is both unnecessary and cause additional overheads