### PR TITLE
Remove scrollbar CSS

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -1164,21 +1164,6 @@ div.curved {
 }
 
 
-/* webkit scrollbar */
-::-webkit-scrollbar {
-	width: 9px; /* for vertical scrollbars */
-	height: 9px; /* for horizontal scrollbars */
-	border: solid 1px rgba(0, 0, 0, .1);
-}
-
-::-webkit-scrollbar-track {
-	background: rgba(0, 0, 0, .1);
-}
-
-::-webkit-scrollbar-thumb {
-	background: rgba(50, 50, 50, .3);
-}
-
 .page-source {
 	word-break: break-all;
 }


### PR DESCRIPTION
Sigma-9 currently alters scrollbar appearance with the non-standard `::-webkit-` pseudo-elements.

This is both incompatible with Firefox and a (admittedly small) accessibility obstacle. In my opinion, it is better to not touch the scrollbar at all and let the UA handle it.

On Safari and most Chromium browsers, this will result in slightly less horizontal space.