### PR TITLE
Update development tools / CI workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: ./build.sh

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Stylelint
+name: Lint
 
 on:
   push:

--- a/.github/workflows/stylelint.yaml
+++ b/.github/workflows/stylelint.yaml
@@ -14,5 +14,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
+      - name: Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Stylelint
-        uses: actions-hub/stylelint@master
+        run: npm run stylelint
+
+      - name: Prettier
+        run: npm run prettier

--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -1,0 +1,4 @@
+semi = true
+singleQuote = true
+quoteProps = "consistent"
+trailingComma = "all"

--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -4,27 +4,26 @@ extends: stylelint-config-standard
 
 rules:
   max-nesting-depth: 2
-
   no-unknown-animations: true
 
   rule-empty-line-before:
     - always
     - except: ['after-single-line-comment', 'first-nested']
+
   import-notation: url
+  selector-type-case: lower
   value-keyword-case: lower
   font-family-name-quotes: always-where-recommended
   color-function-notation: legacy
   alpha-value-notation: number
+  custom-property-empty-line-before: never
 
   comment-empty-line-before:
     - always
     - except: ['first-nested']
+
   comment-whitespace-inside: always
   comment-word-disallowed-list: ['TODO', 'FIXME']
-
-  custom-property-empty-line-before: never
-
-  selector-type-case: lower
 
   # Remove these rules eventually, see https://scuttle.atlassian.net/browse/TT-56
   property-no-vendor-prefix: null

--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -17,6 +17,7 @@ rules:
   color-function-notation: legacy
   alpha-value-notation: number
   custom-property-empty-line-before: never
+  media-feature-range-notation: prefix
 
   comment-empty-line-before:
     - always

--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -3,29 +3,16 @@
 extends: stylelint-config-standard
 
 rules:
-  linebreaks: unix
-  indentation: tab
-  unicode-bom: never
-
-  max-empty-lines: 2
-  max-line-length: 80
   max-nesting-depth: 2
-  no-eol-whitespace: true
-  no-empty-first-line: true
-  no-missing-end-of-source-newline: true
 
   no-unknown-animations: true
 
-  number-leading-zero: never
   rule-empty-line-before:
     - always
     - except: ['after-single-line-comment', 'first-nested']
   import-notation: url
-  property-case: lower
   value-keyword-case: lower
-  string-quotes: single
   font-family-name-quotes: always-where-recommended
-  color-hex-case: lower
   color-function-notation: legacy
   alpha-value-notation: number
 
@@ -35,69 +22,9 @@ rules:
   comment-whitespace-inside: always
   comment-word-disallowed-list: ['TODO', 'FIXME']
 
-  value-list-comma-newline-after: always-multi-line
-  value-list-comma-newline-before: never-multi-line
-  value-list-comma-space-after: always-single-line
-  value-list-comma-space-before: never
-  value-list-max-empty-lines: 0
-
-  declaration-block-semicolon-newline-after: always-multi-line
-  declaration-block-semicolon-newline-before: never-multi-line
-  declaration-block-semicolon-space-after: always-single-line
-  declaration-block-semicolon-space-before: never
-  declaration-block-trailing-semicolon: always
-
-  declaration-bang-space-after: never
-  declaration-bang-space-before: always
-  declaration-colon-newline-after: always-multi-line
-  declaration-colon-space-after: always-single-line
-  declaration-colon-space-before: never
-  declaration-empty-line-before: never
-
   custom-property-empty-line-before: never
 
-  block-closing-brace-empty-line-before: never
-  block-closing-brace-newline-after: always
-  block-closing-brace-newline-before: always
-  block-closing-brace-space-after: never-single-line
-  block-closing-brace-space-before: always-single-line
-  block-opening-brace-newline-after: always-multi-line
-  block-opening-brace-newline-before: never-single-line
-  block-opening-brace-space-after: always-single-line
-  block-opening-brace-space-before: always
-
-  selector-list-comma-newline-after: always-multi-line
-  selector-list-comma-newline-before: never-multi-line
-  selector-list-comma-space-after: always-single-line
-  selector-list-comma-space-before: never-single-line
-
-  selector-attribute-brackets-space-inside: never
-  selector-attribute-operator-space-after: never
-  selector-attribute-operator-space-before: never
-  selector-combinator-space-after: always
-  selector-combinator-space-before: always
-  selector-descendant-combinator-no-non-space: true
-  selector-pseudo-class-case: lower
-  selector-pseudo-class-parentheses-space-inside: never
-  selector-pseudo-element-case: lower
   selector-type-case: lower
-
-  at-rule-name-case: lower
-  at-rule-name-space-after: always-single-line
-  at-rule-semicolon-newline-after: always
-  at-rule-semicolon-space-before: never
-
-  media-query-list-comma-newline-after: always-multi-line
-  media-query-list-comma-newline-before: never-multi-line
-  media-query-list-comma-space-after: always
-  media-query-list-comma-space-before: never
-
-  media-feature-colon-space-after: always
-  media-feature-colon-space-before: never
-  media-feature-name-case: lower
-  media-feature-parentheses-space-inside: never
-  media-feature-range-operator-space-after: always
-  media-feature-range-operator-space-before: always
 
   # Remove these rules eventually, see https://scuttle.atlassian.net/browse/TT-56
   property-no-vendor-prefix: null

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## Sigma-9
 
 <p>
-  <a href="https://github.com/scpwiki/sigma9/actions?query=workflow%3A%22Stylelint%22">
-    <img src="https://github.com/scpwiki/sigma9/workflows/Stylelint/badge.svg"
+  <a href="https://github.com/scpwiki/sigma9/actions?query=workflow%3A%22Lint%22">
+    <img src="https://github.com/scpwiki/sigma9/workflows/Lelint/badge.svg"
          alt="Rust CI badge">
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ $ npm install
 Once this is configured, there are a few scripts you can take advantage of:
 
 ```
-$ npm run build     # Builds the theme and outputs to dist/
-$ npm run clean     # Deletes dist/
-$ npm run lint      # Runs stylelint, reporting any issues
-$ npm run lint:fix  # Runs stylelint, automatically fixing issues
-$ npm run minify    # Minifies sigma9.css and places it into dist/
+$ npm run build         # Builds the theme and outputs to dist/
+$ npm run clean         # Deletes dist/
+$ npm run stylelint     # Runs stylelint, reporting any code issues
+$ npm run stylelint:fix # Runs stylelint, automatically fixing issues
+$ npm run prettier      # Runs prettier, reporting any formatting issues
+$ npm run prettier:fix  # Runs prettier, automatically fixing issues
+$ npm run minify        # Minifies sigma9.css and places it into dist/
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "CC-BY-SA-3.0",
       "devDependencies": {
         "minify": "^9.2.0",
-        "stylelint": "^14.16.1"
+        "prettier": "^2.8.7",
+        "stylelint": "^15.4.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -48,10 +49,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@csstools/selector-specificity": {
+    "node_modules/@csstools/css-parser-algorithms": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.1.0.tgz",
-      "integrity": "sha512-zJ6hb3FDgBbO8d2e83vg6zq7tNvDqSq9RwdwfzJ8tdm9JHNvANq2fqwyRn6mlpUb7CwTs5ILdUrGwi9Gk4vY5w==",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.1.0.tgz",
+      "integrity": "sha512-KP8TicdXpUyeB1NMlbHud/1l39xvLGvqNFWMpG4qC6H1zs9SadGUHe5SO92n/659sDW9aGDvm9AMru0DZkN1Bw==",
       "dev": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
@@ -61,7 +62,52 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.4",
+        "@csstools/css-tokenizer": "^2.0.0"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.1.0.tgz",
+      "integrity": "sha512-dtqFyoJBHUxGi9zPZdpCKP1xk8tq6KPHJ/NY4qWXiYo6IcSGwzk3L8x2XzZbbyOyBs9xQARoGveU2AsgLj6D2A==",
+      "dev": true,
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.0.2.tgz",
+      "integrity": "sha512-8V6JD8Av1HttuClYr1ZBu0LRVe5Nnz4qrv8RppO8mobsX/USBHZy5JQOXYIlpOVhl46nzkx3X5cfH6CqUghjrQ==",
+      "dev": true,
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.0.0",
+        "@csstools/css-tokenizer": "^2.0.0"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
+      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
+      "dev": true,
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
+      "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
       }
     },
@@ -170,12 +216,6 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
-    },
     "node_modules/acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -224,6 +264,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -400,19 +446,21 @@
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
+      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
       "dev": true,
       "dependencies": {
-        "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
         "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
+        "path-type": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
       }
     },
     "node_modules/css-b64-images": {
@@ -434,6 +482,19 @@
       "dev": true,
       "engines": {
         "node": ">=12.22"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/cssesc": {
@@ -1012,6 +1073,18 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -1034,9 +1107,9 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
-      "integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.27.0.tgz",
+      "integrity": "sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==",
       "dev": true
     },
     "node_modules/lines-and-columns": {
@@ -1105,6 +1178,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true
     },
     "node_modules/meow": {
       "version": "9.0.0",
@@ -1552,6 +1631,21 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -1983,16 +2077,20 @@
       "dev": true
     },
     "node_modules/stylelint": {
-      "version": "14.16.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
-      "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.4.0.tgz",
+      "integrity": "sha512-TlOvpG3MbcFwHmK0q2ykhmpKo7Dq892beJit0NPdpyY9b1tFah/hGhqnAz/bRm2PDhDbJLKvjzkEYYBEz7Dxcg==",
       "dev": true,
       "dependencies": {
-        "@csstools/selector-specificity": "^2.0.2",
+        "@csstools/css-parser-algorithms": "^2.1.0",
+        "@csstools/css-tokenizer": "^2.1.0",
+        "@csstools/media-query-list-parser": "^2.0.1",
+        "@csstools/selector-specificity": "^2.2.0",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
-        "cosmiconfig": "^7.1.0",
+        "cosmiconfig": "^8.1.3",
         "css-functions-list": "^3.1.0",
+        "css-tree": "^2.3.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.2.12",
         "fastest-levenshtein": "^1.0.16",
@@ -2001,17 +2099,17 @@
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^3.2.0",
-        "ignore": "^5.2.1",
+        "ignore": "^5.2.4",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.26.0",
+        "known-css-properties": "^0.27.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^9.0.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.19",
+        "postcss": "^8.4.21",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^6.0.0",
@@ -2021,17 +2119,17 @@
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
-        "supports-hyperlinks": "^2.3.0",
+        "supports-hyperlinks": "^3.0.0",
         "svg-tags": "^1.0.0",
         "table": "^6.8.1",
         "v8-compile-cache": "^2.3.0",
-        "write-file-atomic": "^4.0.2"
+        "write-file-atomic": "^5.0.0"
       },
       "bin": {
         "stylelint": "bin/stylelint.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": "^14.13.1 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2051,16 +2149,16 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+      "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
     "node_modules/supports-hyperlinks/node_modules/has-flag": {
@@ -2249,16 +2347,16 @@
       "dev": true
     },
     "node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
+      "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
       "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/yallist": {
@@ -2266,15 +2364,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs-parser": {
       "version": "20.2.9",
@@ -2325,10 +2414,30 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@csstools/selector-specificity": {
+    "@csstools/css-parser-algorithms": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.1.0.tgz",
-      "integrity": "sha512-zJ6hb3FDgBbO8d2e83vg6zq7tNvDqSq9RwdwfzJ8tdm9JHNvANq2fqwyRn6mlpUb7CwTs5ILdUrGwi9Gk4vY5w==",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.1.0.tgz",
+      "integrity": "sha512-KP8TicdXpUyeB1NMlbHud/1l39xvLGvqNFWMpG4qC6H1zs9SadGUHe5SO92n/659sDW9aGDvm9AMru0DZkN1Bw==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/css-tokenizer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.1.0.tgz",
+      "integrity": "sha512-dtqFyoJBHUxGi9zPZdpCKP1xk8tq6KPHJ/NY4qWXiYo6IcSGwzk3L8x2XzZbbyOyBs9xQARoGveU2AsgLj6D2A==",
+      "dev": true
+    },
+    "@csstools/media-query-list-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.0.2.tgz",
+      "integrity": "sha512-8V6JD8Av1HttuClYr1ZBu0LRVe5Nnz4qrv8RppO8mobsX/USBHZy5JQOXYIlpOVhl46nzkx3X5cfH6CqUghjrQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/selector-specificity": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
+      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
       "dev": true,
       "requires": {}
     },
@@ -2419,12 +2528,6 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
-    "@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
-    },
     "acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -2457,6 +2560,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "array-union": {
       "version": "2.1.0",
@@ -2602,16 +2711,15 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
+      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
       "dev": true,
       "requires": {
-        "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
         "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
+        "path-type": "^4.0.0"
       }
     },
     "css-b64-images": {
@@ -2625,6 +2733,16 @@
       "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
       "integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
       "dev": true
+    },
+    "css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "requires": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      }
     },
     "cssesc": {
       "version": "3.0.0",
@@ -3062,6 +3180,15 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -3081,9 +3208,9 @@
       "dev": true
     },
     "known-css-properties": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
-      "integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.27.0.tgz",
+      "integrity": "sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==",
       "dev": true
     },
     "lines-and-columns": {
@@ -3135,6 +3262,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true
+    },
+    "mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true
     },
     "meow": {
@@ -3458,6 +3591,12 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "dev": true
+    },
     "punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -3770,16 +3909,20 @@
       "dev": true
     },
     "stylelint": {
-      "version": "14.16.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
-      "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.4.0.tgz",
+      "integrity": "sha512-TlOvpG3MbcFwHmK0q2ykhmpKo7Dq892beJit0NPdpyY9b1tFah/hGhqnAz/bRm2PDhDbJLKvjzkEYYBEz7Dxcg==",
       "dev": true,
       "requires": {
-        "@csstools/selector-specificity": "^2.0.2",
+        "@csstools/css-parser-algorithms": "^2.1.0",
+        "@csstools/css-tokenizer": "^2.1.0",
+        "@csstools/media-query-list-parser": "^2.0.1",
+        "@csstools/selector-specificity": "^2.2.0",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
-        "cosmiconfig": "^7.1.0",
+        "cosmiconfig": "^8.1.3",
         "css-functions-list": "^3.1.0",
+        "css-tree": "^2.3.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.2.12",
         "fastest-levenshtein": "^1.0.16",
@@ -3788,17 +3931,17 @@
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^3.2.0",
-        "ignore": "^5.2.1",
+        "ignore": "^5.2.4",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.26.0",
+        "known-css-properties": "^0.27.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^9.0.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.19",
+        "postcss": "^8.4.21",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^6.0.0",
@@ -3808,11 +3951,11 @@
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
-        "supports-hyperlinks": "^2.3.0",
+        "supports-hyperlinks": "^3.0.0",
         "svg-tags": "^1.0.0",
         "table": "^6.8.1",
         "v8-compile-cache": "^2.3.0",
-        "write-file-atomic": "^4.0.2"
+        "write-file-atomic": "^5.0.0"
       }
     },
     "supports-color": {
@@ -3825,9 +3968,9 @@
       }
     },
     "supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+      "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0",
@@ -3982,9 +4125,9 @@
       "dev": true
     },
     "write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
+      "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",
@@ -3995,12 +4138,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
     },
     "yargs-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "devDependencies": {
         "minify": "^9.2.0",
         "prettier": "^2.8.7",
-        "stylelint": "^15.4.0"
+        "stylelint": "^15.4.0",
+        "stylelint-config-standard": "^32.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2136,6 +2137,27 @@
         "url": "https://opencollective.com/stylelint"
       }
     },
+    "node_modules/stylelint-config-recommended": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-11.0.0.tgz",
+      "integrity": "sha512-SoGIHNI748OCZn6BxFYT83ytWoYETCINVHV3LKScVAWQQauWdvmdDqJC5YXWjpBbxg2E761Tg5aUGKLFOVhEkA==",
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": "^15.3.0"
+      }
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-32.0.0.tgz",
+      "integrity": "sha512-UnGJxYDyYFrIE9CjDMZRkrNh2o4lOtO+MVZ9qG5b8yARfsWho0GMx4YvhHfsv8zKKgHeWX2wfeyxmuoqcaYZ4w==",
+      "dev": true,
+      "dependencies": {
+        "stylelint-config-recommended": "^11.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^15.4.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3956,6 +3978,22 @@
         "table": "^6.8.1",
         "v8-compile-cache": "^2.3.0",
         "write-file-atomic": "^5.0.0"
+      }
+    },
+    "stylelint-config-recommended": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-11.0.0.tgz",
+      "integrity": "sha512-SoGIHNI748OCZn6BxFYT83ytWoYETCINVHV3LKScVAWQQauWdvmdDqJC5YXWjpBbxg2E761Tg5aUGKLFOVhEkA==",
+      "dev": true,
+      "requires": {}
+    },
+    "stylelint-config-standard": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-32.0.0.tgz",
+      "integrity": "sha512-UnGJxYDyYFrIE9CjDMZRkrNh2o4lOtO+MVZ9qG5b8yARfsWho0GMx4YvhHfsv8zKKgHeWX2wfeyxmuoqcaYZ4w==",
+      "dev": true,
+      "requires": {
+        "stylelint-config-recommended": "^11.0.0"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "scripts": {
     "build": "./build.sh",
     "clean": "rm -rf dist",
-    "lint": "stylelint sigma9.css",
-    "lint:fix": "stylelint --fix sigma9.css",
     "minify": "minify sigma9.css > dist/css/sigma9.min.css",
+    "stylelint": "stylelint sigma9.css",
+    "stylelint:fix": "stylelint --fix sigma9.css",
     "prettier": "prettier sigma9.css",
     "prettier:fix": "prettier --fix sigma9.css"
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "clean": "rm -rf dist",
     "lint": "stylelint sigma9.css",
     "lint:fix": "stylelint --fix sigma9.css",
-    "minify": "minify sigma9.css > dist/css/sigma9.min.css"
+    "minify": "minify sigma9.css > dist/css/sigma9.min.css",
+    "prettier": "prettier sigma9.css",
+    "prettier:fix": "prettier --fix sigma9.css"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "minify": "minify sigma9.css > dist/css/sigma9.min.css",
     "stylelint": "stylelint sigma9.css",
     "stylelint:fix": "stylelint --fix sigma9.css",
-    "prettier": "prettier sigma9.css",
-    "prettier:fix": "prettier --fix sigma9.css"
+    "prettier": "prettier -c sigma9.css",
+    "prettier:fix": "prettier -w sigma9.css"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "minify": "^9.2.0",
     "prettier": "^2.8.7",
-    "stylelint": "^15.4.0"
+    "stylelint": "^15.4.0",
+    "stylelint-config-standard": "^32.0.0"
   },
   "scripts": {
     "build": "./build.sh",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "devDependencies": {
     "minify": "^9.2.0",
-    "stylelint": "^14.16.1"
+    "prettier": "^2.8.7",
+    "stylelint": "^15.4.0"
   },
   "scripts": {
     "build": "./build.sh",

--- a/sigma9.css
+++ b/sigma9.css
@@ -18,7 +18,8 @@
 	font-style: normal;
 	font-weight: 100 900;
 	font-display: swap;
-	src: url('https://scpwiki.github.io/sigma9/fonts/Inter-roman.var.woff2?v=3.19') format('woff2');
+	src: url('https://scpwiki.github.io/sigma9/fonts/Inter-roman.var.woff2?v=3.19')
+		format('woff2');
 }
 
 @font-face {
@@ -26,7 +27,8 @@
 	font-style: italic;
 	font-weight: 100 900;
 	font-display: swap;
-	src: url('https://scpwiki.github.io/sigma9/fonts/Inter-italic.var.woff2?v=3.19') format('woff2');
+	src: url('https://scpwiki.github.io/sigma9/fonts/Inter-italic.var.woff2?v=3.19')
+		format('woff2');
 }
 
 @font-face {
@@ -34,7 +36,8 @@
 	font-style: normal;
 	font-weight: 700;
 	font-display: swap;
-	src: url('https://scpwiki.github.io/sigma9/fonts/Sans-Normalcy.woff2') format('woff2');
+	src: url('https://scpwiki.github.io/sigma9/fonts/Sans-Normalcy.woff2')
+		format('woff2');
 }
 
 @font-face {
@@ -42,7 +45,8 @@
 	font-style: normal;
 	font-weight: 400;
 	font-display: swap;
-	src: url('https://scpwiki.github.io/sigma9/fonts/NanumGothic-Regular.woff2') format('woff2');
+	src: url('https://scpwiki.github.io/sigma9/fonts/NanumGothic-Regular.woff2')
+		format('woff2');
 }
 
 @font-face {
@@ -50,7 +54,8 @@
 	font-style: normal;
 	font-weight: 700;
 	font-display: swap;
-	src: url('https://scpwiki.github.io/sigma9/fonts/NanumGothic-Bold.woff2') format('woff2');
+	src: url('https://scpwiki.github.io/sigma9/fonts/NanumGothic-Bold.woff2')
+		format('woff2');
 }
 
 /* COMMON */
@@ -62,21 +67,26 @@
 	height: auto;
 }
 
-h1, #page-title {
+h1,
+#page-title {
 	color: #901;
-	padding: 0 0 .25em;
-	margin: 0 0 .6em;
+	padding: 0 0 0.25em;
+	margin: 0 0 0.6em;
 	font-weight: normal;
 }
 
 h1 {
-	margin-top: .7em;
+	margin-top: 0.7em;
 	padding: 0;
 	font-weight: bold;
 }
 
-h2, h3, h4, h5, h6 {
-	margin: .5em 0 .4em;
+h2,
+h3,
+h4,
+h5,
+h6 {
+	margin: 0.5em 0 0.4em;
 	padding: 0;
 	letter-spacing: 1px;
 }
@@ -89,8 +99,8 @@ h2, h3, h4, h5, h6 {
 	border-bottom: solid 1px #bbb;
 	color: #901;
 	font-weight: normal;
-	margin: 0 0 .6em;
-	padding: 0 0 .25em;
+	margin: 0 0 0.6em;
+	padding: 0 0 0.25em;
 	font-size: 2em;
 }
 
@@ -102,7 +112,8 @@ ul {
 	list-style: square;
 }
 
-li, p {
+li,
+p {
 	line-height: 1.5;
 }
 
@@ -137,7 +148,8 @@ a.newpage {
 }
 
 /* GLOBAL WIDTH */
-#header, #top-bar {
+#header,
+#top-bar {
 	width: 90%;
 	max-width: 64rem;
 	margin: 0 auto;
@@ -153,24 +165,15 @@ a.newpage {
 
 body {
 	background-color: #fff;
-	font-size: .95em;
+	font-size: 0.95em;
 	color: #333;
-	font-family:
-		Inter,
-		BlinkMacSystemFont,
-		'Segoe UI',
-		Roboto,
-		Oxygen,
-		Ubuntu,
-		Cantarell,
-		'Fira Sans',
-		'Droid Sans',
-		'Helvetica Neue',
-		sans-serif;
+	font-family: Inter, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+		Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 	font-feature-settings: 'case', 'ss01', 'ss04';
 }
 
-input, textarea {
+input,
+textarea {
 	font-family: inherit;
 }
 
@@ -179,13 +182,14 @@ input, textarea {
 }
 
 div#container-wrap {
-	background: url('https://scp-wiki.wdfiles.com/local--files/component:theme/body_bg.png') top left repeat-x;
+	background: url('https://scp-wiki.wdfiles.com/local--files/component:theme/body_bg.png')
+		top left repeat-x;
 }
 
 sup {
 	vertical-align: top;
 	position: relative;
-	top: -.5em;
+	top: -0.5em;
 }
 
 /* HEADER */
@@ -194,7 +198,8 @@ sup {
 	position: relative;
 	z-index: 10;
 	padding-bottom: 22px; /* FOR MENU */
-	background: url('https://scp-wiki.wdfiles.com/local--files/component:theme/logo.png') 10px 40px no-repeat;
+	background: url('https://scp-wiki.wdfiles.com/local--files/component:theme/logo.png')
+		10px 40px no-repeat;
 	background-size: 100px;
 	background-position: 10px 64%;
 }
@@ -237,12 +242,12 @@ sup {
 	border: solid 1px #999;
 	border-radius: 5px;
 	padding: 2px 5px;
-	font-size: .9em;
+	font-size: 0.9em;
 	font-weight: bold;
 	color: #ccc;
 	background-color: #633;
 	background-image: linear-gradient(to bottom, #966, #633, #300);
-	box-shadow: 0 1px 3px rgba(0, 0, 0, .5);
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 	cursor: pointer;
 }
 
@@ -250,15 +255,15 @@ sup {
 #search-top-box-form input[type='submit']:focus {
 	border: solid 1px #fff;
 	color: #fff;
-	text-shadow: 0 0 1px rgba(255, 255, 255, .25);
+	text-shadow: 0 0 1px rgba(255, 255, 255, 0.25);
 	background-color: #966;
 	background-image: linear-gradient(to bottom, #c99, #966, #633);
-	box-shadow: 0 1px 3px rgba(0, 0, 0, .8);
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
 }
 
 #login-status {
 	color: #aaa;
-	font-size: .9em;
+	font-size: 0.9em;
 	z-index: 30;
 }
 
@@ -309,7 +314,7 @@ sup {
 	font-size: 1.5em;
 	text-decoration: none;
 	text-shadow: 3px 3px 5px #000;
-	letter-spacing: .9px;
+	letter-spacing: 0.9px;
 }
 
 #header h2 span {
@@ -321,7 +326,7 @@ sup {
 	font-weight: bold;
 	color: #f0f0c0;
 	text-shadow: 1px 1px 1px #000;
-	text-shadow: 1px 1px 1px rgba(0, 0, 0, .8);
+	text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.8);
 }
 
 /* TOP MENU */
@@ -334,7 +339,7 @@ sup {
 	padding: 0;
 	margin: 0 auto;
 	z-index: 20;
-	font-size: .9em;
+	font-size: 0.9em;
 }
 
 #top-bar ul {
@@ -357,17 +362,17 @@ sup {
 
 #top-bar ul li ul {
 	border: solid 1px #666;
-	box-shadow: 0 2px 6px rgba(0, 0, 0, .5);
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 	border-top: 0;
 	border-width: 0 1px;
 	width: auto;
 }
 
 #top-bar ul li a {
-	border-left: solid 1px rgba(64, 64, 64, .1);
-	border-right: solid 1px rgba(64, 64, 64, .1);
+	border-left: solid 1px rgba(64, 64, 64, 0.1);
+	border-right: solid 1px rgba(64, 64, 64, 0.1);
 	text-decoration: none;
-	padding: 0 min(.75vw, 1em);
+	padding: 0 min(0.75vw, 1em);
 	line-height: 21px;
 }
 
@@ -412,7 +417,8 @@ sup {
 	border-width: 0;
 }
 
-#top-bar ul li ul a, #top-bar a:hover {
+#top-bar ul li ul a,
+#top-bar a:hover {
 	color: #a01;
 }
 
@@ -420,13 +426,12 @@ sup {
 	right: 0;
 }
 
-
 /* SIDE MENU */
 #side-bar {
 	clear: none;
 	float: none;
 	position: absolute;
-	top: .5rem;
+	top: 0.5rem;
 	left: 1.5rem;
 	width: 14rem;
 	padding: 0;
@@ -444,7 +449,7 @@ sup {
 	padding: 10px;
 	border: 1px solid #600;
 	border-radius: 10px;
-	box-shadow: 0 2px 6px rgba(102, 0, 0, .5);
+	box-shadow: 0 2px 6px rgba(102, 0, 0, 0.5);
 	background: #fff;
 	margin-bottom: 15px;
 }
@@ -468,7 +473,7 @@ sup {
 	padding-left: 15px;
 	margin-top: 10px;
 	margin-bottom: 5px;
-	font-size: .75em;
+	font-size: 0.75em;
 	font-weight: bold;
 }
 
@@ -489,7 +494,7 @@ sup {
 
 /* For sidebar item with smaller text, like SCP series links */
 #side-bar .menu-item.small {
-	font-size: .9em;
+	font-size: 0.9em;
 }
 
 #side-bar .menu-item img,
@@ -508,7 +513,7 @@ sup {
 }
 
 #side-bar .menu-item.inactive img {
-	opacity: .25;
+	opacity: 0.25;
 }
 
 #side-bar .menu-item.inactive a {
@@ -516,7 +521,7 @@ sup {
 }
 
 #side-bar .menu-item .sub-text {
-	font-size: .8em;
+	font-size: 0.8em;
 	color: #666;
 }
 
@@ -533,7 +538,7 @@ sup {
 	margin-top: 10px;
 	margin-bottom: 5px;
 	margin-left: 15px;
-	font-size: .675em;
+	font-size: 0.675em;
 	color: #600;
 }
 
@@ -564,9 +569,9 @@ sup {
 		font-weight: 700;
 		width: 30px;
 		height: 30px;
-		line-height: .9em;
+		line-height: 0.9em;
 		text-align: center;
-		border: .2em solid #888;
+		border: 0.2em solid #888;
 		background-color: #fff;
 		border-radius: 3em;
 		color: #888;
@@ -589,9 +594,9 @@ sup {
 		overflow-y: auto;
 		z-index: 10;
 		padding: 1rem 1rem 0;
-		-webkit-transition: left .5s ease-in-out .1s;
-		-o-transition: left .5s ease-in-out .1s;
-		transition: left .5s ease-in-out .1s;
+		-webkit-transition: left 0.5s ease-in-out 0.1s;
+		-o-transition: left 0.5s ease-in-out 0.1s;
+		transition: left 0.5s ease-in-out 0.1s;
 	}
 
 	#side-bar::after {
@@ -600,7 +605,7 @@ sup {
 		top: 0;
 		width: 0;
 		height: 100%;
-		background-color: rgba(0, 0, 0, .2);
+		background-color: rgba(0, 0, 0, 0.2);
 	}
 
 	#side-bar:target {
@@ -614,7 +619,7 @@ sup {
 		height: 100%;
 		top: 0;
 		left: 0;
-		background: rgba(0, 0, 0, .3) 1px 1px repeat;
+		background: rgba(0, 0, 0, 0.3) 1px 1px repeat;
 		z-index: -1;
 	}
 }
@@ -622,7 +627,7 @@ sup {
 /* CONTENT */
 #main-content {
 	margin: 0 1.5rem 0 18rem;
-	padding: .875rem;
+	padding: 0.875rem;
 	position: relative;
 }
 
@@ -652,14 +657,19 @@ sup {
 
 .yui-navset .yui-nav .selected a,
 .yui-navset .yui-nav .selected a:focus,
-.yui-navset .yui-nav .selected a:hover { /* no hover effect for selected */
-	background: #700 url('https://d3g0gp89917ko0.cloudfront.net/v--3b8418686296/common--theme/shiny/images/yuitabs.png') repeat-x left -1400px; /* selected tab background */
+.yui-navset .yui-nav .selected a:hover {
+	/* no hover effect for selected */
+	background: #700
+		url('https://d3g0gp89917ko0.cloudfront.net/v--3b8418686296/common--theme/shiny/images/yuitabs.png')
+		repeat-x left -1400px; /* selected tab background */
 	color: #fff;
 }
 
 .yui-navset .yui-nav a:hover,
 .yui-navset .yui-nav a:focus {
-	background: #d88 url('https://d3g0gp89917ko0.cloudfront.net/v--3b8418686296/common--theme/shiny/images/yuitabs.png') repeat-x left -1300px;
+	background: #d88
+		url('https://d3g0gp89917ko0.cloudfront.net/v--3b8418686296/common--theme/shiny/images/yuitabs.png')
+		repeat-x left -1300px;
 	text-decoration: none;
 }
 
@@ -675,7 +685,7 @@ sup {
 /* FOOTER */
 #footer {
 	clear: both;
-	font-size: .77em;
+	font-size: 0.77em;
 	background: #444;
 	color: #bbb;
 	margin-top: 15px;
@@ -727,12 +737,11 @@ div.sexy-box div.image-container img {
 	background-color: #999990;
 	margin: 10px 0 15px;
 	box-shadow: 3px 3px 6px #bbb;
-	box-shadow:
-		0 2px 6px rgba(0, 0, 0, .5),
-		inset 0 1px rgba(255, 255, 255, .3),
-		inset 0 10px rgba(255, 255, 255, .2),
-		inset 0 10px 20px rgba(255, 255, 255, .25),
-		inset 0 -15px 30px rgba(0, 0, 0, .1);
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5),
+		inset 0 1px rgba(255, 255, 255, 0.3),
+		inset 0 10px rgba(255, 255, 255, 0.2),
+		inset 0 10px 20px rgba(255, 255, 255, 0.25),
+		inset 0 -15px 30px rgba(0, 0, 0, 0.1);
 }
 
 .content-panel.standalone {
@@ -761,9 +770,9 @@ div.sexy-box div.image-container img {
 .content-panel .panel-heading {
 	padding: 2px 10px;
 	color: #fff;
-	font-size: .9em;
+	font-size: 0.9em;
 	font-weight: bold;
-	text-shadow: 1px 1px 2px rgba(0, 0, 0, .35);
+	text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.35);
 }
 
 .content-panel .panel-heading > p,
@@ -773,16 +782,18 @@ div.sexy-box div.image-container img {
 
 .content-panel .panel-body {
 	padding: 5px 10px;
-	background: #fff9f0 url('https://scp-wiki.wdfiles.com/local--files/component:theme/panel-bg-gradient-reverse.png') bottom repeat-x;
+	background: #fff9f0
+		url('https://scp-wiki.wdfiles.com/local--files/component:theme/panel-bg-gradient-reverse.png')
+		bottom repeat-x;
 }
 
 .content-panel .panel-footer {
 	padding: 1px 10px;
 	color: #fffff0;
-	font-size: .8em;
+	font-size: 0.8em;
 	font-weight: bold;
 	text-align: right;
-	text-shadow: 1px 1px 2px rgba(0, 0, 0, .5);
+	text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
 }
 
 .content-panel .panel-footer a {
@@ -797,18 +808,18 @@ div.sexy-box div.image-container img {
 	border-radius: 10px;
 	margin: 20px 0 5px 5px;
 	white-space: nowrap;
-	box-shadow: inset 1px 2px 6px rgba(0, 0, 0, .15);
+	box-shadow: inset 1px 2px 6px rgba(0, 0, 0, 0.15);
 }
 
 .alternate:nth-child(even) {
-	background-color: rgba(255, 255, 255, .9);
+	background-color: rgba(255, 255, 255, 0.9);
 }
 
 /* Page Rating Module Customizations */
 .page-rate-widget-box {
 	display: inline-block;
 	border-radius: 5px;
-	box-shadow: 1px 1px 3px rgba(0, 0, 0, .5);
+	box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.5);
 	margin-bottom: 10px;
 	margin-right: 2em;
 }
@@ -884,7 +895,7 @@ div.page-rate-widget-box .rate-points {
 /* Standard Image Block */
 .scp-image-block {
 	border: solid 1px #666;
-	box-shadow: 0 1px 6px rgba(0, 0, 0, .25);
+	box-shadow: 0 1px 6px rgba(0, 0, 0, 0.25);
 	width: 300px;
 }
 
@@ -913,7 +924,7 @@ div.page-rate-widget-box .rate-points {
 	background-color: #eee;
 	border-top: solid 1px #666;
 	padding: 2px 0;
-	font-size: .8em;
+	font-size: 0.8em;
 	font-weight: bold;
 	text-align: center;
 }
@@ -935,19 +946,19 @@ div.page-rate-widget-box .rate-points {
 /* Wikiwalk Navigation */
 .footer-wikiwalk-nav {
 	font-weight: bold;
-	font-size: .75em;
+	font-size: 0.75em;
 }
 
 /* Licensebox */
 .licensebox .collapsible-block-link {
-	margin-left: .25em;
-	padding: .25em;
+	margin-left: 0.25em;
+	padding: 0.25em;
 	font-weight: bold;
-	opacity: .5;
+	opacity: 0.5;
 	color: inherit;
-	-webkit-transition: opacity .5s ease-in-out;
-	-moz-transition: opacity .5s ease-in-out;
-	transition: opacity .5s ease-in-out;
+	-webkit-transition: opacity 0.5s ease-in-out;
+	-moz-transition: opacity 0.5s ease-in-out;
+	transition: opacity 0.5s ease-in-out;
 }
 
 .licensebox .collapsible-block-link:hover,
@@ -957,27 +968,26 @@ div.page-rate-widget-box .rate-points {
 
 /* Forum Customizations */
 .forum-thread-box .description-block {
-	padding: .5em 1em;
+	padding: 0.5em 1em;
 	border-radius: 10px;
-	box-shadow:
-		0 1px 5px rgba(0, 0, 0, .15),
-		inset 0 1px 0 rgba(255, 255, 255, .8),
-		inset 0 10px 5px rgba(255, 255, 255, .25),
-		inset 0 -15px 30px rgba(0, 0, 0, .1);
+	box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15),
+		inset 0 1px 0 rgba(255, 255, 255, 0.8),
+		inset 0 10px 5px rgba(255, 255, 255, 0.25),
+		inset 0 -15px 30px rgba(0, 0, 0, 0.1);
 }
 
 .thread-container .post .head {
-	padding: .5em 1em;
+	padding: 0.5em 1em;
 	background-color: #eee;
 	background-image: linear-gradient(to right, #eee, #eeecec);
-	box-shadow: inset 2px 3px 6px rgba(0, 0, 0, .15);
+	box-shadow: inset 2px 3px 6px rgba(0, 0, 0, 0.15);
 	border-radius: 5px 5px 0 0;
 }
 
 /* Adding Forum Lines */
 .post-container .post-container {
-	border-left: 2px solid rgba(0, 0, 0, .25);
-	padding-left: .75rem;
+	border-left: 2px solid rgba(0, 0, 0, 0.25);
+	padding-left: 0.75rem;
 }
 
 /* Hide Forum Signatures */
@@ -991,7 +1001,8 @@ div.page-rate-widget-box .rate-points {
 }
 
 /* Ruby by Nanimono Demonai */
-.ruby, ruby {
+.ruby,
+ruby {
 	display: inline-table;
 	text-align: center;
 	white-space: nowrap;
@@ -1000,9 +1011,10 @@ div.page-rate-widget-box .rate-points {
 	vertical-align: text-bottom;
 }
 
-.rt, rt {
+.rt,
+rt {
 	display: table-header-group;
-	font-size: .6em;
+	font-size: 0.6em;
 	line-height: 1.1;
 	text-align: center;
 	white-space: nowrap;
@@ -1019,7 +1031,7 @@ div.page-rate-widget-box .rate-points {
 	background-color: #f9f9f9;
 	padding: 1px 3px;
 	font-family: inherit;
-	font-size: .85em;
+	font-size: 0.85em;
 	white-space: nowrap;
 }
 
@@ -1124,7 +1136,7 @@ div.curved {
 	blockquote,
 	div.blockquote,
 	div.curved {
-		margin: .5em;
+		margin: 0.5em;
 	}
 }
 
@@ -1163,13 +1175,17 @@ div.curved {
 	-webkit-text-emphasis-style: dot;
 }
 
-
 .page-source {
 	word-break: break-all;
 }
 
 /* Responsive Web Design */
-img, embed, video, object, iframe, table {
+img,
+embed,
+video,
+object,
+iframe,
+table {
 	max-width: 100%;
 }
 
@@ -1186,12 +1202,13 @@ img, embed, video, object, iframe, table {
 		max-width: 90%;
 		margin: 0 5%;
 		padding: 0;
-		-webkit-transition: .5s ease-in-out .1s;
-		-o-transition: .5s ease-in-out .1s;
-		transition: .5s ease-in-out .1s;
+		-webkit-transition: 0.5s ease-in-out 0.1s;
+		-o-transition: 0.5s ease-in-out 0.1s;
+		transition: 0.5s ease-in-out 0.1s;
 	}
 
-	span, a {
+	span,
+	a {
 		overflow-wrap: break-word;
 	}
 
@@ -1207,7 +1224,8 @@ img, embed, video, object, iframe, table {
 		z-index: 1;
 	}
 
-	#navi-bar, #navi-bar-shadow {
+	#navi-bar,
+	#navi-bar-shadow {
 		display: none;
 	}
 
@@ -1216,7 +1234,7 @@ img, embed, video, object, iframe, table {
 	}
 
 	.license-area {
-		font-size: .9em;
+		font-size: 0.9em;
 	}
 
 	/* owindow */
@@ -1225,7 +1243,8 @@ img, embed, video, object, iframe, table {
 		max-width: 99%;
 	}
 
-	.modal-body .table, .modal-body .table ~ div {
+	.modal-body .table,
+	.modal-body .table ~ div {
 		float: left;
 	}
 
@@ -1249,12 +1268,13 @@ img, embed, video, object, iframe, table {
 		background-position: 8px 64%;
 	}
 
-	#header h1, #header h2 {
+	#header h1,
+	#header h2 {
 		margin-left: calc(48px + 8%);
 	}
 
 	#header h1 a {
-		font-size: calc(.75em + 2vw);
+		font-size: calc(0.75em + 2vw);
 	}
 
 	#search-top-box-input {
@@ -1280,7 +1300,7 @@ img, embed, video, object, iframe, table {
 	}
 
 	#page-content {
-		font-size: .9em;
+		font-size: 0.9em;
 	}
 
 	#recent-posts-category {
@@ -1292,10 +1312,11 @@ img, embed, video, object, iframe, table {
 	}
 
 	.license-area {
-		font-size: .8em;
+		font-size: 0.8em;
 	}
 
-	table.form td, table.form th {
+	table.form td,
+	table.form th {
 		float: left;
 		padding: 0;
 	}
@@ -1304,12 +1325,14 @@ img, embed, video, object, iframe, table {
 		max-width: 90%;
 	}
 
-	.content-panel.left-column, .content-panel.right-column {
+	.content-panel.left-column,
+	.content-panel.right-column {
 		width: 99%;
 		float: left;
 	}
 
-	#page-content div, #page-content div table {
+	#page-content div,
+	#page-content div table {
 		clear: both;
 	}
 
@@ -1331,7 +1354,7 @@ iframe.scpnet-interwiki-frame {
 div#u-adult-warning {
 	width: fit-content;
 	margin: 0 auto 20px;
-	padding: .5rem 1rem;
+	padding: 0.5rem 1rem;
 	border: 3px solid #333;
 	background: #e4e4e4;
 	color: #333;
@@ -1341,7 +1364,7 @@ div#u-adult-warning {
 
 div#u-adult-warning > div#u-adult-header {
 	font-size: 3em;
-	text-shadow: 1px 2px 3px rgba(0, 0, 0, .5);
+	text-shadow: 1px 2px 3px rgba(0, 0, 0, 0.5);
 	color: #901;
 }
 

--- a/sigma9.css
+++ b/sigma9.css
@@ -662,6 +662,7 @@ sup {
 	background: #700
 		url('https://d3g0gp89917ko0.cloudfront.net/v--3b8418686296/common--theme/shiny/images/yuitabs.png')
 		repeat-x left -1400px; /* selected tab background */
+
 	color: #fff;
 }
 


### PR DESCRIPTION
[Stylelint 15.0 was released](https://stylelint.io/migration-guide/to-15/), which brings with it deprecation of their formatting lints. After upgrading our tooling in `package.json`, I have added prettier as the new code formatter. I added options to make it closer to the existing style, but some changes were needed here.

Additionally, I have renamed the "Stylelint" flow to simply "Lint" and added the prettier check there via direct npm commands. Consequently, I have updated the badge and instructions in the README. There was an [issue with previous builds](https://github.com/scpwiki/sigma9/actions/runs/4594587438/jobs/8113796187) where an outdated GH workflow step was causing the build to not run.