### PR TITLE
Monospace Page Edit Lock Timer

### DIFF
--- a/sigma.css
+++ b/sigma.css
@@ -1396,9 +1396,8 @@ div#u-adult-warning > .error-block {
 
 /*
   Make the page edit lock timer monospaced so it does not shift page layout
-	as it counts down. The font-family property is set to 'monospace, monospace'
-	instead of 'monospace' because this makes it match the surrounding font size.
+	as it counts down.
 */
 #lock-timer {
-	font-family: monospace, monospace;
+	font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
This just makes the Page Edit Lock timer use the system monospace font. This will prevent it from constantly layout-shifting as it counts down. While minor, this can be a distraction for authors.

Before:
<img width="205" height="111" alt="image" src="https://github.com/user-attachments/assets/9b1a9ac1-5e4a-4c45-9d8a-50bc6062478b" />

After:
<img width="172" height="97" alt="image" src="https://github.com/user-attachments/assets/31bfdf61-9802-4418-a4b6-daf3c6ca9465" />
